### PR TITLE
fixing solr docker image

### DIFF
--- a/contrib/docker/solr/Dockerfile
+++ b/contrib/docker/solr/Dockerfile
@@ -24,14 +24,19 @@ ENV \
   CKAN_VERSION=2.2.3
 
 RUN mkdir -p /opt/solr
-ADD https://archive.apache.org/dist/lucene/solr/$SOLR_VERSION/solr-$SOLR_VERSION.tgz /opt/solr-$SOLR_VERSION.tgz
+# In 17.06-ce this command unarchive tgz automatically to /opt/solr-4.10.4.tgz/solr-4.10.4
+#ADD https://archive.apache.org/dist/lucene/solr/$SOLR_VERSION/solr-$SOLR_VERSION.tgz /opt/solr-$SOLR_VERSION.tgz
+RUN wget https://archive.apache.org/dist/lucene/solr/$SOLR_VERSION/solr-$SOLR_VERSION.tgz -O /opt/solr-$SOLR_VERSION.tgz
 RUN tar zxf /opt/solr-$SOLR_VERSION.tgz -C /opt/solr --strip-components 1
 
 # Install CKAN Solr core
 RUN cp -R $SOLR_HOME/collection1/ $SOLR_HOME/ckan/
 RUN echo name=ckan > $SOLR_HOME/ckan/core.properties
+# There is no schema.xml in this repository
 #ADD schema.xml $SOLR_HOME/ckan/conf/schema.xml
+# Changed to wget to have more consistent image
 ADD https://github.com/ckan/ckan/raw/ckan-$CKAN_VERSION/ckan/config/solr/schema.xml $SOLR_HOME/ckan/conf/schema.xml
+RUN wget https://github.com/ckan/ckan/raw/ckan-$CKAN_VERSION/ckan/config/solr/schema.xml -O $SOLR_HOME/ckan/conf/schema.xml
 
 EXPOSE 8983
 WORKDIR /opt/solr/example


### PR DESCRIPTION
Dockerfile ADD command changed behaviour in 17.06-ce. Directly adding .tgz automatically unpack the archive. I modified Dockerfile to use wget for solr archive and schema.xml download. Also, schema.xml is missing from the current folder, I commented out unnecessary statement.